### PR TITLE
Swallow handler fix

### DIFF
--- a/src/AspComet.Specifications/MessageHandlers/SwallowHandlerSpecs.cs
+++ b/src/AspComet.Specifications/MessageHandlers/SwallowHandlerSpecs.cs
@@ -18,7 +18,42 @@ namespace AspComet.Specifications.MessageHandlers
         It should_raise_a_published_event_with_the_request_message =()=>
             eventHubMonitor.RaisedEvent<PublishingEvent>().Message.ShouldEqual(request);
 
-        It should_not_return_a_result = () =>
-            result.ShouldBeNull();
+        It should_not_return_a_response_message = () =>
+            result.Message.ShouldBeNull();
+
+        It should_specify_that_the_result_cannot_be_treated_as_a_long_poll = () =>
+            result.CanTreatAsLongPoll.ShouldBeFalse();
     }
+
+    public class when_swallowing_a_message_and_the_publishing_event_is_cancelled : MessageHandlerScenario<SwallowHandler>
+    {
+        private const string CancellationReason = "ThisIsTheCancellationReasonForSwallowing";
+
+        Establish context = () => {
+            EventHub.Subscribe<PublishingEvent>(x =>
+            {
+                x.Cancel = true;
+                x.CancellationReason = CancellationReason;
+            });
+            eventHubMonitor.StartMonitoring<PublishingEvent>();
+        };
+
+        Because of = () =>
+            result = SUT.HandleMessage(request);
+
+        Behaves_like<ItHasHandledAMessage> has_handled_a_message;
+
+        It should_raise_a_published_event_with_the_request_message =()=>
+            eventHubMonitor.RaisedEvent<PublishingEvent>().Message.ShouldEqual(request);
+
+        It should_send_an_unsuccessful_response = () =>
+            result.Message.successful.ShouldEqual( false );
+
+        It should_send_an_unsuccessful_response_with_error_equal_to_cancellation_reason = () =>
+            result.Message.error.ShouldEqual( CancellationReason );
+
+        It should_specify_that_the_result_cannot_be_treated_as_a_long_poll = () =>
+            result.CanTreatAsLongPoll.ShouldBeFalse();
+    }
+
 }

--- a/src/AspComet/MessageHandlers/SwallowHandler.cs
+++ b/src/AspComet/MessageHandlers/SwallowHandler.cs
@@ -13,7 +13,23 @@ namespace AspComet.MessageHandlers
             var e = new PublishingEvent(request);
             EventHub.Publish(e);
 
-            return null;
+            Message msg = null;
+            if ( e.Cancel ) {
+                msg = new Message
+                {
+                    id = request.id,
+                    clientId = request.clientId,
+                    channel = request.channel,
+                    successful = false,
+                    error = e.CancellationReason
+                };
+            }
+
+            return new MessageHandlerResult
+            {
+                Message = msg,
+                CanTreatAsLongPoll = false
+            };
         }
     }
 }


### PR DESCRIPTION
The original SwallowHandler would cause exceptions, because it returns null which is not supported by MessageProcessor. I've changed the code to return result with null message instead (and to return failed response if publishing is cancelled)

// Robert
