### PR TITLE
Message converter injection

### DIFF
--- a/src/AspComet.Specifications/HttpHandlerSpecs.cs
+++ b/src/AspComet.Specifications/HttpHandlerSpecs.cs
@@ -125,6 +125,7 @@ namespace AspComet.Specifications
         protected static IMessageBus messageBus;
         protected static HttpContextBase httpContext;
         protected static HttpRequestBase httpRequest;
+        protected static IMessageConverter messageConverter;
 
         Establish context =()=>
         {
@@ -133,10 +134,12 @@ namespace AspComet.Specifications
             httpRequest = MockRepository.GenerateStub<HttpRequestBase>();
             httpContext = MockRepository.GenerateStub<HttpContextBase>();
             serviceLocator = MockRepository.GenerateStub<IServiceLocator>();
+            messageConverter = new MessageConverter(new MessageSerializer());
 
             httpContext.Stub(x => x.Request).Return(httpRequest);
             httpRequest.Stub(x => x.Form).Return(new NameValueCollection());
             serviceLocator.Stub(x => x.GetInstance<IMessageBus>()).Return(messageBus);
+            serviceLocator.Stub(x => x.GetInstance<IMessageConverter>()).Return(messageConverter);
 
             ServiceLocator.SetLocatorProvider(() => serviceLocator);
         };

--- a/src/AspComet.Specifications/Transports/CallingPollingTransportSpecs.cs
+++ b/src/AspComet.Specifications/Transports/CallingPollingTransportSpecs.cs
@@ -8,6 +8,7 @@ using Machine.Specifications;
 
 using Rhino.Mocks;
 using Rhino.Mocks.Constraints;
+using Microsoft.Practices.ServiceLocation;
 
 namespace AspComet.Specifications.Transports
 {
@@ -51,19 +52,26 @@ namespace AspComet.Specifications.Transports
 
     public abstract class CallbackPollingTransportScenario
     {
+        protected static IServiceLocator serviceLocator;
+        protected static IMessageConverter messageConverter;
         protected static Message[] messages;
         protected static string messagesAsJson;
         protected static HttpResponseBase httpResponse;
 
         Establish context = () =>
         {
+            messageConverter = new MessageConverter(new MessageSerializer());
+            serviceLocator = MockRepository.GenerateStub<IServiceLocator>();
+            serviceLocator.Stub(x => x.GetInstance<IMessageConverter>()).Return(messageConverter);
+            ServiceLocator.SetLocatorProvider(() => serviceLocator);
+
             messages = new[]
             { 
                 MessageBuilder.BuildWithRandomPropertyValues(),
                 MessageBuilder.BuildWithRandomPropertyValues()
             };
 
-            messagesAsJson = MessageConverter.ToJson(messages);
+            messagesAsJson = messageConverter.ToJson(messages);
             httpResponse = MockRepository.GenerateStub<HttpResponseBase>();
         };
     }

--- a/src/AspComet/AspComet.csproj
+++ b/src/AspComet/AspComet.csproj
@@ -61,6 +61,9 @@
     <Compile Include="CometAsyncResult.cs" />
     <Compile Include="CometHttpHandler.cs" />
     <Compile Include="IClientWorkflowManager.cs" />
+    <Compile Include="IMessageConverter.cs" />
+    <Compile Include="IMessageSerializer.cs" />
+    <Compile Include="MessageSerializer.cs" />
     <Compile Include="ServiceMetadata.cs" />
     <Compile Include="Setup.cs" />
     <Compile Include="Eventing\CancellableEvent.cs" />

--- a/src/AspComet/CometHttpHandler.cs
+++ b/src/AspComet/CometHttpHandler.cs
@@ -28,7 +28,7 @@ namespace AspComet
 
         public IAsyncResult BeginProcessRequest(HttpContextBase context, AsyncCallback callback, object asyncState)
         {
-            Message[] request = MessageConverter.FromJson(context.Request);
+            Message[] request = GetMessageConverter().FromJson(context.Request);
             CometAsyncResult asyncResult = new CometAsyncResult(context, callback, asyncState);
             GetMessageBus().HandleMessages(request, asyncResult);
             return asyncResult;
@@ -43,6 +43,17 @@ namespace AspComet
             }
 
             return serviceLocator.GetInstance<IMessageBus>();
+        }
+
+        private static IMessageConverter GetMessageConverter()
+        {
+            IServiceLocator serviceLocator = ServiceLocator.Current;
+            if (serviceLocator == null)
+            {
+                throw new ConfigurationErrorsException("AspComet has not been configured. Either use the default configuration or set up a service locator");
+            }
+
+            return serviceLocator.GetInstance<IMessageConverter>();
         }
 
         public void EndProcessRequest(IAsyncResult result)

--- a/src/AspComet/IMessageConverter.cs
+++ b/src/AspComet/IMessageConverter.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web;
+
+namespace AspComet
+{
+    public interface IMessageConverter
+    {
+        Message[] FromJson(HttpRequestBase request);
+        string ToJson<TModel>(TModel model);
+    }
+}

--- a/src/AspComet/IMessageSerializer.cs
+++ b/src/AspComet/IMessageSerializer.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AspComet
+{
+    public interface IMessageSerializer
+    {
+        T Deserialize<T>(string input);
+        string Serialize(object model);
+    }
+}

--- a/src/AspComet/MessageConverter.cs
+++ b/src/AspComet/MessageConverter.cs
@@ -5,13 +5,17 @@ using System.Web.Script.Serialization;
 
 namespace AspComet
 {
-    public class MessageConverter 
+    public class MessageConverter: IMessageConverter
     {
-        private static readonly JavaScriptSerializer Serializer = new JavaScriptSerializer();
+        private readonly IMessageSerializer Serializer;
         private static readonly Regex ArrayRegex = new Regex(@"^\s*\[", RegexOptions.Compiled);
-        private static readonly Regex NullRegex = new Regex(@"(""[^""]+"":null,)|(,""[^""]+"":null)", RegexOptions.Compiled);
 
-        public static Message[] FromJson(HttpRequestBase request)
+        public MessageConverter(IMessageSerializer serializer)
+        {
+            Serializer = serializer;
+        }
+
+        public Message[] FromJson(HttpRequestBase request)
         {
             // Get the "message" parameter from the post collection, as specified in Bayeux sec. 3.4.
             // Dojo seems to just send the message as the body, without any name, so cater for that too.
@@ -33,10 +37,9 @@ namespace AspComet
                 return reader.ReadToEnd();
         }
 
-        public static string ToJson<TModel>(TModel model)
+        public string ToJson<TModel>(TModel model)
         {
-            string txt = Serializer.Serialize(model);
-            return NullRegex.Replace(txt, string.Empty);
+            return Serializer.Serialize(model);
         }
     }
 }

--- a/src/AspComet/MessageSerializer.cs
+++ b/src/AspComet/MessageSerializer.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Web.Script.Serialization;
+using System.Text.RegularExpressions;
+
+namespace AspComet
+{
+    public class MessageSerializer: IMessageSerializer
+    {
+        private readonly JavaScriptSerializer Serializer = new JavaScriptSerializer();
+        private static readonly Regex NullRegex = new Regex(@"(""[^""]+"":null,)|(,""[^""]+"":null)", RegexOptions.Compiled);
+
+        public T Deserialize<T>(string input)
+        {
+            return Serializer.Deserialize<T>(input);
+        }
+
+        public string Serialize(object model)
+        {
+            string txt = Serializer.Serialize(model);
+            return NullRegex.Replace(txt, string.Empty);
+        }
+    }
+}

--- a/src/AspComet/ServiceMetadata.cs
+++ b/src/AspComet/ServiceMetadata.cs
@@ -25,6 +25,8 @@ namespace AspComet
             yield return new ServiceMetadata { ServiceType = typeof(IMessagesProcessor), ActualType = typeof(MessagesProcessor), IsPerRequest = true };
             yield return new ServiceMetadata { ServiceType = typeof(IMessageBus), ActualType = typeof(MessageBus) };
             yield return new ServiceMetadata { ServiceType = typeof(IClientWorkflowManager), ActualType = typeof(ClientWorkflowManager) };
+            yield return new ServiceMetadata { ServiceType = typeof(IMessageConverter), ActualType = typeof(MessageConverter) };
+            yield return new ServiceMetadata { ServiceType = typeof(IMessageSerializer), ActualType = typeof(MessageSerializer) };
         }
     }
 }

--- a/src/AspComet/Transports/CallbackPollingTransport.cs
+++ b/src/AspComet/Transports/CallbackPollingTransport.cs
@@ -1,20 +1,23 @@
 ﻿using System.Collections.Generic;
 using System.Web;
+using Microsoft.Practices.ServiceLocation;
 
 namespace AspComet.Transports
 {
     public class CallbackPollingTransport : ITransport
     {
+        private readonly IMessageConverter messageConverter;
         private readonly string callback;
 
         public CallbackPollingTransport(string callback)
         {
+            this.messageConverter = ServiceLocator.Current.GetInstance<IMessageConverter>();
             this.callback = callback;
         }
 
         public void SendMessages(HttpResponseBase response, IEnumerable<Message> messages)
         {
-            string messageAsJson = MessageConverter.ToJson(messages);
+            string messageAsJson = messageConverter.ToJson(messages);
             string functionName = callback ?? "jsonpcallback";
             string functionCall = string.Format("{0} ( {1} )", functionName, messageAsJson);
 

--- a/src/AspComet/Transports/LongPollingTransport.cs
+++ b/src/AspComet/Transports/LongPollingTransport.cs
@@ -1,17 +1,24 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Web;
+using Microsoft.Practices.ServiceLocation;
 
 namespace AspComet.Transports
 {
     public class LongPollingTransport : ITransport
     {
+        private readonly IMessageConverter messageConverter;
         public static LongPollingTransport Instance = new LongPollingTransport();
+
+        public LongPollingTransport()
+        {
+            this.messageConverter = ServiceLocator.Current.GetInstance<IMessageConverter>();
+        }
 
         public void SendMessages(HttpResponseBase response, IEnumerable<Message> messages)
         {
             response.ContentType = "text/json";
-            response.Write(MessageConverter.ToJson(messages));
+            response.Write(messageConverter.ToJson(messages));
         }
     }
 }


### PR DESCRIPTION
I have extracted the message converter and serializer so they are injectable.

The reason I did this, is because I need finer grained control on the handling of data containing 'null' values. Right now, the serializer just removes all 'null' values. This is fine for the bayeux message properties, but it is _not_ okay for all of the properties contained in 'data'.

The fact that these null values are stripped off may be even considered a bug?
